### PR TITLE
feat: allow querying flights by arrival airport

### DIFF
--- a/anyflights-main/R/anyflights.R
+++ b/anyflights-main/R/anyflights.R
@@ -10,8 +10,8 @@
 #'   \item \code{\link{get_airlines}}: Grab data to translate between two letter 
 #'   carrier codes and names
 #'   \item \code{\link{get_airports}}: Grab data on airport names and locations
-#'   \item \code{\link{get_flights}}: Grab data on all flights that departed 
-#'   given US airports in a given year and month
+#'   \item \code{\link{get_flights}}: Grab data on flights that departed or
+#'   arrived at given US airports in a given year and month
 #'   \item \code{\link{get_planes}}: Grab construction information about each 
 #'   plane
 #'   \item \code{\link{get_weather}}: Grab hourly meterological data for a given 
@@ -25,8 +25,9 @@
 #' codes for all supported airports. See 
 #' ?\code{\link{get_flights}} for more details on implementation.
 #' 
-#' @param station A character vector giving the origin US airports of interest
-#'  (as the FAA LID airport code).
+#' @param station A character vector giving the US airports of interest
+#'  (as the FAA LID airport code). Flights are matched by departure airport by
+#'  default; set `arrivals = TRUE` to match by arrival airport instead.
 #'  
 #' @param year A numeric giving the year of interest. This argument is currently
 #' not vectorized, as dataset sizes for single years are significantly large.
@@ -38,7 +39,11 @@
 #' @param dir An optional character string giving the directory
 #' to save datasets in. By default, datasets will not be saved to file.
 #' 
-#' @return A list of dataframes (and, optionally, a directory of datasets) 
+#' @param arrivals Logical; when `FALSE` (default) flights are filtered by
+#'   departure airport(s) given in `station`. When `TRUE`, flights are filtered by
+#'   arrival airport(s).
+#'
+#' @return A list of dataframes (and, optionally, a directory of datasets)
 #' similar to those found in the \code{nycflights13} data package.
 #' 
 #' @examples
@@ -62,7 +67,8 @@
 #' of this function to a data-only package.
 #' 
 #' @export
-anyflights <- function(station, year, month = 1:12, dir = NULL) {
+anyflights <- function(station, year, month = 1:12, dir = NULL,
+                       arrivals = FALSE) {
   
   # create a function, unique to this call to anyflights,
   # that returns the difference in time from when the function was called
@@ -81,7 +87,8 @@ anyflights <- function(station, year, month = 1:12, dir = NULL) {
   }
   
   write_tick(pb, "  Processing Arguments...")
-  flights <- get_flights(station, year, month, dir, 
+  flights <- get_flights(station, year, month, dir,
+                         arrivals = arrivals,
                          pb = pb, diff_fn = diff_from_start)
   write_message(pb, "Finished Downloading Flights Data", diff_from_start)
   

--- a/anyflights-main/R/get_flights.R
+++ b/anyflights-main/R/get_flights.R
@@ -7,13 +7,18 @@
 #' may take several minutes to download relevant data.
 #' 
 #' This function currently downloads data for \emph{all} stations for each month
-#' supplied, and \emph{then} filters out data for relevant stations. Thus, 
-#' the recommended approach to download data for many airports is to supply 
-#' a vector of airport codes to the \code{station} argument rather than 
-#' iterating over many calls to \code{get_flights()}.
+#' supplied, and \emph{then} filters out data for relevant stations. Thus,
+#' the recommended approach to download data for many airports is to supply
+#' a vector of airport codes to the \code{station} argument rather than
+#' iterating over many calls to \code{get_flights()}. By default, flights are
+#' filtered by departure airport; setting \code{arrivals = TRUE} filters by
+#' arrival airport instead.
 #' 
-#' @inheritParams anyflights 
-#' 
+#' @inheritParams anyflights
+#'
+#' @param arrivals Logical; when `FALSE` (default) flights are filtered by
+#'   departure airport(s) given in `station`. When `TRUE`, flights are filtered
+#'   by arrival airport(s).
 #' @param ... Currently only used internally.
 #' 
 #' @return A data frame with ~1k-500k rows and 19 variables:
@@ -70,7 +75,8 @@
 #' to a data-only package.
 #'
 #' @export
-get_flights <- function(station, year, month = 1:12, dir = NULL, ...) {
+get_flights <- function(station, year, month = 1:12, dir = NULL,
+                        arrivals = FALSE, ...) {
   
   if (!hasArg(pb)) {
     # if get_flights isn't supplied a progress bar from the anyflights
@@ -90,9 +96,9 @@ get_flights <- function(station, year, month = 1:12, dir = NULL, ...) {
   }
   
   # check user inputs
-  check_arguments(station = station, 
-                  year = year, 
-                  month = month, 
+  check_arguments(station = station,
+                  year = year,
+                  month = month,
                   dir = dir,
                   context = "flights")
   
@@ -119,7 +125,8 @@ get_flights <- function(station, year, month = 1:12, dir = NULL, ...) {
   # load in the flights data for each month, tidy it, and rowbind it
   flights <- purrr::map(dir(flight_exdir, full.names = TRUE),
                         get_flight_data,
-                        station = station) %>%
+                        station = station,
+                        arrivals = arrivals) %>%
     dplyr::bind_rows() %>%
     dplyr::arrange(year, month, day, dep_time)
   

--- a/anyflights-main/R/utils.R
+++ b/anyflights-main/R/utils.R
@@ -18,7 +18,7 @@ check_arguments <- function(station = NULL, year = NULL,
     }    
     
     if (!all(station %in% get_airports()$faa)) {
-      stop_glue("Couldn't find at least one of the provided origin airports ",
+      stop_glue("Couldn't find at least one of the provided airports ",
                 "{list(station)}. Please consider using the get_airports() function ",
                 "to locate the desired FAA LID code!")
     }
@@ -236,7 +236,7 @@ download_month <- function(year, month, dir, flight_exdir, pb, diff_fn) {
                 diff_fn)
 }
 
-get_flight_data <- function(path, station) {
+get_flight_data <- function(path, station, arrivals = FALSE) {
   
   # read in the data
   suppressWarnings(
@@ -246,24 +246,24 @@ get_flight_data <- function(path, station) {
     ) %>%
     # select relevant columns
     dplyr::select(
-      year = Year, 
-      month = Month, 
+      year = Year,
+      month = Month,
       day = DayofMonth,
-      dep_time = DepTime, 
-      sched_dep_time = CRSDepTime, 
+      dep_time = DepTime,
+      sched_dep_time = CRSDepTime,
       dep_delay = DepDelay,
-      arr_time = ArrTime, 
-      sched_arr_time = CRSArrTime, 
+      arr_time = ArrTime,
+      sched_arr_time = CRSArrTime,
       arr_delay = ArrDelay,
-      carrier = Reporting_Airline,  
-      flight = Flight_Number_Reporting_Airline, 
-      tailnum = Tail_Number, 
-      origin = Origin, 
-      dest = Dest, 
-      air_time = AirTime, 
+      carrier = Reporting_Airline,
+      flight = Flight_Number_Reporting_Airline,
+      tailnum = Tail_Number,
+      origin = Origin,
+      dest = Dest,
+      air_time = AirTime,
       distance = Distance) %>%
-    # only keep the relevant rows
-    dplyr::filter(origin %in% station) %>%
+    {if (arrivals) dplyr::filter(., dest %in% station)
+     else dplyr::filter(., origin %in% station)} %>%
     dplyr::mutate(
       # convert column classes
       dep_time = as.integer(dep_time),

--- a/anyflights-main/man/anyflights.Rd
+++ b/anyflights-main/man/anyflights.Rd
@@ -4,11 +4,12 @@
 \alias{anyflights}
 \title{Query nycflights13-Like Air Travel Data}
 \usage{
-anyflights(station, year, month = 1:12, dir = NULL)
+anyflights(station, year, month = 1:12, dir = NULL, arrivals = FALSE)
 }
 \arguments{
-\item{station}{A character vector giving the origin US airports of interest
-(as the FAA LID airport code).}
+\item{station}{A character vector giving the US airports of interest
+(as the FAA LID airport code). Flights are matched by departure airport by
+default; set \code{arrivals = TRUE} to match by arrival airport instead.}
 
 \item{year}{A numeric giving the year of interest. This argument is currently
 not vectorized, as dataset sizes for single years are significantly large.
@@ -19,6 +20,10 @@ March in the following year.}
 
 \item{dir}{An optional character string giving the directory
 to save datasets in. By default, datasets will not be saved to file.}
+
+\item{arrivals}{Logical; when \code{FALSE} (default) flights are filtered by
+departure airport(s) given in \code{station}. When \code{TRUE}, flights are
+filtered by arrival airport(s).}
 }
 \value{
 A list of dataframes (and, optionally, a directory of datasets) 
@@ -36,9 +41,9 @@ The \code{anyflights()} function is a wrapper around the following functions:
   \item \code{\link{get_airlines}}: Grab data to translate between two letter 
   carrier codes and names
   \item \code{\link{get_airports}}: Grab data on airport names and locations
-  \item \code{\link{get_flights}}: Grab data on all flights that departed 
-  given US airports in a given year and month
-  \item \code{\link{get_planes}}: Grab construction information about each 
+  \item \code{\link{get_flights}}: Grab data on flights that departed or
+  arrived at given US airports in a given year and month
+  \item \code{\link{get_planes}}: Grab construction information about each
   plane
   \item \code{\link{get_weather}}: Grab hourly meterological data for a given 
   airport in a given year and month

--- a/anyflights-main/man/get_flights.Rd
+++ b/anyflights-main/man/get_flights.Rd
@@ -8,11 +8,12 @@ RITA, Bureau of transportation statistics,
  \url{https://www.bts.gov}
 }
 \usage{
-get_flights(station, year, month = 1:12, dir = NULL, ...)
+get_flights(station, year, month = 1:12, dir = NULL, arrivals = FALSE, ...)
 }
 \arguments{
-\item{station}{A character vector giving the origin US airports of interest
-(as the FAA LID airport code).}
+\item{station}{A character vector giving the US airports of interest
+(as the FAA LID airport code). Flights are matched by departure airport by
+default; set \code{arrivals = TRUE} to match by arrival airport instead.}
 
 \item{year}{A numeric giving the year of interest. This argument is currently
 not vectorized, as dataset sizes for single years are significantly large.
@@ -23,6 +24,10 @@ March in the following year.}
 
 \item{dir}{An optional character string giving the directory
 to save datasets in. By default, datasets will not be saved to file.}
+
+\item{arrivals}{Logical; when \code{FALSE} (default) flights are filtered by
+departure airport(s) given in \code{station}. When \code{TRUE}, flights are
+filtered by arrival airport(s).}
 
 \item{...}{Currently only used internally.}
 }
@@ -61,8 +66,10 @@ may take several minutes to download relevant data.
 This function currently downloads data for \emph{all} stations for each month
 supplied, and \emph{then} filters out data for relevant stations. Thus, 
 the recommended approach to download data for many airports is to supply 
-a vector of airport codes to the \code{station} argument rather than 
-iterating over many calls to \code{get_flights()}.
+a vector of airport codes to the \code{station} argument rather than
+iterating over many calls to \code{get_flights()}. By default, flights are
+filtered by departure airport; setting \code{arrivals = TRUE} filters by
+arrival airport instead.
 }
 \note{
 If you are repeatedly getting a timeout error when downloading flights,

--- a/anyflights-main/tests/testthat/test-1-get-flights.R
+++ b/anyflights-main/tests/testthat/test-1-get-flights.R
@@ -4,8 +4,17 @@ test_that("standard get_flights (PDX, June 2018)", {
   skip_on_cran()
   skip_if_offline()
   skip_on_os("windows")
-  
+
   flights_ <- get_flights("PDX", 2018, 6)
+})
+
+test_that("get_flights can filter by arrival airport", {
+  skip_on_cran()
+  skip_if_offline()
+  skip_on_os("windows")
+
+  flights_arr <- get_flights("PDX", 2018, 6, arrivals = TRUE)
+  expect_true(all(flights_arr$dest == "PDX"))
 })
 
 test_that("standard get_flights (NYC, February 2013)", {


### PR DESCRIPTION
## Summary
- extend `get_flights()` with `arrivals` flag to filter by destination airports
- propagate arrival filtering through `anyflights()` wrapper and utilities
- add regression test covering arrival-based queries

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: command not found: R`)*

------
https://chatgpt.com/codex/tasks/task_e_6891809f01888321b89d6852ff63eb14