### PR TITLE
feat: support arrival flight queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # anyflights (development version)
 
+* Add `type` argument to `get_flights()` and `anyflights()` to retrieve
+  flights by arrival or departure airport.
+
 # anyflights 0.3.5
 
 * Include `tz = "GMT"` argument to `ISOdatetime()` so that weather output isn't 

--- a/R/anyflights.R
+++ b/R/anyflights.R
@@ -34,9 +34,13 @@
 #' March in the following year.
 #' 
 #' @param month A numeric giving the month(s) of interest.
-#' 
+#'
 #' @param dir An optional character string giving the directory
 #' to save datasets in. By default, datasets will not be saved to file.
+#'
+#' @param type Either "departure" (the default) to return flights departing
+#'   from the supplied stations or "arrival" to return flights arriving at the
+#'   supplied stations.
 #' 
 #' @return A list of dataframes (and, optionally, a directory of datasets) 
 #' similar to those found in the \code{nycflights13} data package.
@@ -62,7 +66,10 @@
 #' of this function to a data-only package.
 #' 
 #' @export
-anyflights <- function(station, year, month = 1:12, dir = NULL) {
+anyflights <- function(station, year, month = 1:12, dir = NULL,
+                       type = c("departure", "arrival")) {
+
+  type <- match.arg(type)
   
   # create a function, unique to this call to anyflights,
   # that returns the difference in time from when the function was called
@@ -81,7 +88,7 @@ anyflights <- function(station, year, month = 1:12, dir = NULL) {
   }
   
   write_tick(pb, "  Processing Arguments...")
-  flights <- get_flights(station, year, month, dir, 
+  flights <- get_flights(station, year, month, dir, type = type,
                          pb = pb, diff_fn = diff_from_start)
   write_message(pb, "Finished Downloading Flights Data", diff_from_start)
   

--- a/R/get_flights.R
+++ b/R/get_flights.R
@@ -12,8 +12,11 @@
 #' a vector of airport codes to the \code{station} argument rather than 
 #' iterating over many calls to \code{get_flights()}.
 #' 
-#' @inheritParams anyflights 
-#' 
+#' @inheritParams anyflights
+#'
+#' @param type Either "departure" (the default) to return flights departing
+#'   from the supplied stations or "arrival" to return flights arriving at the
+#'   supplied stations.
 #' @param ... Currently only used internally.
 #' 
 #' @return A data frame with ~1k-500k rows and 19 variables:
@@ -55,6 +58,10 @@
 #' 
 #' # ...or the original nycflights13 flights dataset
 #' \donttest{\dontrun{get_flights(c("JFK", "LGA", "EWR"), 2013)}}
+#'
+#' # flights arriving at the NYC airports in February 2013
+#' \donttest{\dontrun{get_flights(c("JFK", "LGA", "EWR"), 2013, 2,
+#'                                type = "arrival")}}
 #' 
 #' # use the dir argument to indicate the folder to 
 #' # save the data in \code{dir} as "flights.rda"
@@ -70,7 +77,10 @@
 #' to a data-only package.
 #'
 #' @export
-get_flights <- function(station, year, month = 1:12, dir = NULL, ...) {
+get_flights <- function(station, year, month = 1:12, dir = NULL,
+                        type = c("departure", "arrival"), ...) {
+
+  type <- match.arg(type)
   
   if (!hasArg(pb)) {
     # if get_flights isn't supplied a progress bar from the anyflights
@@ -119,7 +129,8 @@ get_flights <- function(station, year, month = 1:12, dir = NULL, ...) {
   # load in the flights data for each month, tidy it, and rowbind it
   flights <- purrr::map(dir(flight_exdir, full.names = TRUE),
                         get_flight_data,
-                        station = station) %>%
+                        station = station,
+                        type = type) %>%
     dplyr::bind_rows() %>%
     dplyr::arrange(year, month, day, dep_time)
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -236,7 +236,7 @@ download_month <- function(year, month, dir, flight_exdir, pb, diff_fn) {
                 diff_fn)
 }
 
-get_flight_data <- function(path, station) {
+get_flight_data <- function(path, station, type) {
   
   # read in the data
   suppressWarnings(
@@ -263,7 +263,15 @@ get_flight_data <- function(path, station) {
       air_time = AirTime, 
       distance = Distance) %>%
     # only keep the relevant rows
-    dplyr::filter(origin %in% station) %>%
+    dplyr::filter(
+      {
+        if (type == "departure") {
+          origin %in% station
+        } else {
+          dest %in% station
+        }
+      }
+    ) %>%
     dplyr::mutate(
       # convert column classes
       dep_time = as.integer(dep_time),

--- a/man/anyflights.Rd
+++ b/man/anyflights.Rd
@@ -4,7 +4,7 @@
 \alias{anyflights}
 \title{Query nycflights13-Like Air Travel Data}
 \usage{
-anyflights(station, year, month = 1:12, dir = NULL)
+anyflights(station, year, month = 1:12, dir = NULL, type = c("departure", "arrival"))
 }
 \arguments{
 \item{station}{A character vector giving the origin US airports of interest
@@ -19,6 +19,10 @@ March in the following year.}
 
 \item{dir}{An optional character string giving the directory
 to save datasets in. By default, datasets will not be saved to file.}
+
+\item{type}{Either "departure" (the default) to return flights departing from
+the supplied stations or "arrival" to return flights arriving at the supplied
+stations.}
 }
 \value{
 A list of dataframes (and, optionally, a directory of datasets) 

--- a/man/get_flights.Rd
+++ b/man/get_flights.Rd
@@ -8,7 +8,7 @@ RITA, Bureau of transportation statistics,
  \url{https://www.bts.gov}
 }
 \usage{
-get_flights(station, year, month = 1:12, dir = NULL, ...)
+get_flights(station, year, month = 1:12, dir = NULL, type = c("departure", "arrival"), ...)
 }
 \arguments{
 \item{station}{A character vector giving the origin US airports of interest
@@ -23,6 +23,10 @@ March in the following year.}
 
 \item{dir}{An optional character string giving the directory
 to save datasets in. By default, datasets will not be saved to file.}
+
+\item{type}{Either "departure" (the default) to return flights departing from
+the supplied stations or "arrival" to return flights arriving at the supplied
+stations.}
 
 \item{...}{Currently only used internally.}
 }
@@ -77,6 +81,9 @@ code \code{options(timeout = timeout_value_in_seconds)} in your console.
 
 # ...or the original nycflights13 flights dataset
 \donttest{\dontrun{get_flights(c("JFK", "LGA", "EWR"), 2013)}}
+
+# flights arriving at the NYC airports in February 2013
+\donttest{\dontrun{get_flights(c("JFK", "LGA", "EWR"), 2013, 2, type = "arrival")}}
 
 # use the dir argument to indicate the folder to 
 # save the data in \code{dir} as "flights.rda"

--- a/tests/testthat/test-1-get-flights.R
+++ b/tests/testthat/test-1-get-flights.R
@@ -23,3 +23,17 @@ test_that("standard get_flights (NYC, February 2013)", {
   expect_equal(purrr::map(flights_2, class) %>% unlist(),
                purrr::map(flights_orig, class) %>% unlist())
 })
+
+test_that("arrival get_flights (NYC, February 2013)", {
+  skip_on_cran()
+  skip_if_offline()
+  skip_on_os("windows")
+
+  flights_arr <- get_flights(c("JFK", "LGA", "EWR"), 2013, 2, type = "arrival")
+  expect_gt(nrow(flights_arr), 0)
+  expect_true(all(flights_arr$dest %in% c("JFK", "LGA", "EWR")))
+
+  flights_dep <- get_flights(c("JFK", "LGA", "EWR"), 2013, 2)
+  expect_equal(ncol(flights_arr), ncol(flights_dep))
+  expect_equal(colnames(flights_arr), colnames(flights_dep))
+})


### PR DESCRIPTION
## Summary
- allow `get_flights()` to filter arrivals via new `type` argument
- add `type` option to `anyflights()` wrapper
- document and test arrival filtering

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68919c29d91c832189b3f19f0f964dc3